### PR TITLE
Add email DNS mini-audit

### DIFF
--- a/.github/workflows/email-lite.yml
+++ b/.github/workflows/email-lite.yml
@@ -1,0 +1,11 @@
+name: Email DNS mini-audit
+on:
+  push:
+  schedule:
+    - cron: '0 3 * * 1'
+jobs:
+  dns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/check_mail_dns.sh spacerunner.com

--- a/index.html
+++ b/index.html
@@ -155,7 +155,7 @@
     <div class="title-container">
         <h1 class="title">faux_sierra_music</h1>
         <p class="subtitle" id="loading-text">loading<span id="dots">...</span></p>
-<p style="text-align:left; position:relative; left:-50%; transform:translateX(50%); padding-left: 60px; padding-right: 60px; margin-top: 0.3rem;"><a href="harry.html" style="color: #dddddd; text-decoration:underline;">&lt;about the owner&gt;</a></p>
+<p style="text-align:left; position:relative; left:-50%; transform:translateX(50%); padding-left: 60px; padding-right: 60px; margin-top: 0.3rem;"><a href="/harry.html" style="color: #dddddd; text-decoration:underline;">&lt;about the owner&gt;</a></p>
     </div>
 
     <script>

--- a/scripts/check_mail_dns.sh
+++ b/scripts/check_mail_dns.sh
@@ -1,0 +1,21 @@
+DOMAIN=$1
+# Check SPF
+if dig +short TXT "$DOMAIN" | grep -q "v=spf1"; then
+  echo "SPF ✅"
+else
+  echo "SPF ❌"
+fi
+
+# Check DKIM using selector 'default'
+if dig +short TXT default._domainkey."$DOMAIN" | grep -q "v=DKIM1"; then
+  echo "DKIM ✅"
+else
+  echo "DKIM ❌"
+fi
+
+# Check DMARC
+if dig +short TXT _dmarc."$DOMAIN" | grep -q "v=DMARC1"; then
+  echo "DMARC ✅"
+else
+  echo "DMARC ❌"
+fi


### PR DESCRIPTION
## Summary
- add script to check SPF, DKIM and DMARC
- run the script weekly in a GitHub workflow
- fix index link so tests pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842eec5bdb08321be831075740890a5