### PR TITLE
Fix Instagram iframe transparency attribute

### DIFF
--- a/harry.html
+++ b/harry.html
@@ -177,7 +177,7 @@
         class="instagram-frame"
         src="https://www.instagram.com/harryfoxaus/embed"
         scrolling="no"
-        allowtransparency="true"
+        allowTransparency="true"
         frameborder="0">
       </iframe>
 
@@ -186,7 +186,7 @@
         class="instagram-frame"
         src="https://www.instagram.com/spacerunnerthedj/embed"
         scrolling="no"
-        allowtransparency="true"
+        allowTransparency="true"
         frameborder="0">
       </iframe>
     </div>


### PR DESCRIPTION
## Summary
- update `harry.html` to use `allowTransparency` for Instagram iframes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842e16ffe008321acb58c8c23d72f02