### PR TITLE
Add shared header font class for consistent headers

### DIFF
--- a/harry.html
+++ b/harry.html
@@ -13,7 +13,7 @@
 
   <!-- Main content container -->
   <div class="content-container">
-    <h1>owner_harryfox</h1>
+    <h1 class="header-text">owner_harryfox</h1>
     <p class="subtitle">email: harry@fauxsierramusic.com</p>
     <a class="back-link" href="index.html">&lt;back&gt;</a>
 

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <div class="code-art-container" id="code-container"></div>
 
     <div class="title-container">
-        <h1 class="title">faux_sierra_music</h1>
+        <h1 class="title header-text">faux_sierra_music</h1>
         <p class="subtitle" id="loading-text">loading<span id="dots">...</span></p>
 <p style="text-align:left; position:relative; left:-50%; transform:translateX(50%); padding-left: 60px; padding-right: 60px; margin-top: 0.3rem;"><a href="/harry.html" style="color: #dddddd; text-decoration:underline;">&lt;about&gt;</a></p>
     </div>

--- a/style.css
+++ b/style.css
@@ -102,6 +102,13 @@ body.no-scroll {
     margin-top: 1rem;
 }
 
+/* Reusable header font styling */
+.header-text {
+    font-family: "Digital", monospace;
+    font-weight: bold;
+    letter-spacing: 0.1em;
+}
+
 /* Containers for owner and playlist pages */
 .content-container {
     display: flex;


### PR DESCRIPTION
## Summary
- add reusable `.header-text` font class
- apply shared header class to homepage and owner page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0ebc1e3f083219e402d564635fea8